### PR TITLE
Upgrade to 4.23.0

### DIFF
--- a/liquibase.properties
+++ b/liquibase.properties
@@ -1,1 +1,1 @@
-liquibase.version=4.15.0
+liquibase.version=4.23.0


### PR DESCRIPTION
The only thing not in .gitignore is the properties file, yet the readme says ***tools and `nuspec` only*** so what do you want in here?